### PR TITLE
Get timestamp working with millisecond accuracy, add tests

### DIFF
--- a/tests/test_uuid7.py
+++ b/tests/test_uuid7.py
@@ -3,21 +3,20 @@
 Tests for `uuid7` package.
 """
 import time
-
-from uuid_extensions import uuid7, uuid7str
+from uuid_extensions import uuid7, uuid7str, uuidfromvalues, format_byte_array_as_uuid, uuid_to_datetime
 
 def test_uuid7():
     """
     Some simple tests
     """
     # Note the sequence value increments by 1 between each of these uuid7(...) calls
-    ns = time.time_ns()
-    out1 = str(uuid7(ns))
-    out2: str = uuid7(ns, as_type='str') # type: ignore
-    out3 = uuid7str(ns)
+    ms = time.time_ns() // 1_000_000
+    out1 = str(uuid7(ms))
+    out2: str = uuid7(ms, as_type='str') # type: ignore
+    out3 = uuid7str(ms)
 
-    assert out1[:20] == out2[:20]
-    assert out2[:20] == out3[:20]
+    assert out1[:13] == out2[:13]
+    assert out2[:13] == out3[:13]
 
 
 def test_monotonicity():
@@ -26,3 +25,27 @@ def test_monotonicity():
         i = uuid7str()
         if n > 0 and i <= last:
             raise RuntimeError(f"UUIDs are not monotonic: {last} versus {i}")
+
+def test_vector():
+    # test vectors from
+    # https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-example-of-a-uuidv7-value
+
+    unix_ts_ms = 0x17F22E279B0
+    rand_a = 0xCC3
+    rand_b = 0x18C4DC0C0C07398F
+
+    expected = "017f22e279b07cc398c4dc0c0c07398f"
+    found = uuidfromvalues(unix_ts_ms, rand_a, rand_b).hex()
+    assert expected == found
+
+def test_formatting():
+    expected = '017f22e2-79b0-7cc3-98c4-dc0c0c07398f'
+    found = format_byte_array_as_uuid(b'\x01\x7f"\xe2y\xb0|\xc3\x98\xc4\xdc\x0c\x0c\x079\x8f')
+    assert expected == found
+
+def test_retrieving_timestamp():
+    test_vector = '017f22e2-79b0-7cc3-98c4-dc0c0c07398f'
+    expected_ms = 1645557742000
+    found = uuid_to_datetime(test_vector)
+    assert found != None
+    assert found.timestamp() == expected_ms / 1000

--- a/uuid_extensions/uuid7.py
+++ b/uuid_extensions/uuid7.py
@@ -9,9 +9,11 @@ Stephen Simmons, v0.1.0, 2021-12-27
 __all__ = (
     "uuid7",
     "uuid7str",
-    "time_ns",
+    "time_ms",
     "check_timing_precision",
     "uuid_to_datetime",
+    "uuidfromvalues",
+    "format_byte_array_as_uuid"
 )
 
 import datetime
@@ -21,14 +23,14 @@ import time
 from typing import Callable, Optional, Union
 import uuid
 
-# Expose function used by uuid7() to get current time in nanoseconds
+# Expose function used by uuid7() to get current time in milliseconds
 # since the Unix epoch.
-time_ns = time.time_ns
+time_ms = lambda: time.time_ns() // 1_000_000
 
 def uuid7(
-    ns: Optional[int] = None,
+    ms: Optional[int] = None,
     as_type: Optional[str] = None,
-    time_func: Callable[[], int] = time_ns,
+    time_func: Callable[[], int] = time_ms,
     _last=[0, 0, 0, 0],
     _last_as_of=[0, 0, 0, 0],
 ) -> Union[uuid.UUID, str, int, bytes]:
@@ -42,22 +44,17 @@ def uuid7(
     Parameters
     ----------
 
-    ns      - Optional integer with the whole number of nanoseconds
+    ms      - Optional integer with the whole number of milliseconds
                 since Unix epoch, to set the "as of" timestamp.
-                As a special case, uuid7(ns=0) returns the zero UUID.
 
     as_type - Optional string to return the UUID in a different format.
                 A uuid.UUID (version 7, variant 0x10) is returned unless
                 this is one of 'str', 'int', 'hex' or 'bytes'.
 
     time_func - Set the time function, which must return integer
-                nanoseconds since the Unix epoch, midnight on 1-Jan-1970.
-                Defaults to time.time_ns(). This is exposed because
+                milliseconds since the Unix epoch, midnight on 1-Jan-1970.
+                Defaults to time.time_ns()/1e6. This is exposed because
                 time.time_ns() may have a low resolution on Windows.
-
-    _last and _last_as_of - Used internally to trigger incrementing a
-                sequence counter when consecutive calls have the same time
-                values. The values [t1, t2, t3, seq] are described below.
 
     Returns
     -------
@@ -76,17 +73,17 @@ def uuid7(
     plus, at locations defined by RFC4122, 4 bits for the
     uuid version (0b111) and 2 bits for the uuid variant (0b10).
 
-             0                   1                   2                   3
-             0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    t1      |                 unixts (secs since epoch)                     |
-            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    t2/t3   |unixts |  frac secs (12 bits)  |  ver  |  frac secs (12 bits)  |
-            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    t4/rand |var|       seq (14 bits)       |          rand (16 bits)       |
-            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    rand    |                          rand (32 bits)                       |
-            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+     0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                           unix_ts_ms                          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |          unix_ts_ms           |  ver  |       rand_a          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |var|                        rand_b                             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                            rand_b                             |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
     Indicative timings:
     - uuid.uuid4()            2.4us
@@ -100,9 +97,6 @@ def uuid7(
     >>> uuid7()
     UUID('061cb26a-54b8-7a52-8000-2124e7041024')
 
-    >>> uuid7(0)
-    UUID('00000000-0000-0000-0000-00000000000')
-
     >>> for fmt in ('bytes', 'hex', 'int', 'str', 'uuid', None):
     ...     print(fmt, repr(uuid7(as_type=fmt)))
     bytes b'\x06\x1c\xb8\xfe\x0f\x0b|9\x80\x00\tjt\x85\xb3\xbb'
@@ -112,66 +106,48 @@ def uuid7(
     uuid UUID('061cb8fe-0f0b-7c39-8004-0489578299f6')
     None UUID('061cb8fe-0f0f-7df2-8000-afd57c2bf446')
     """
-    if ns is None:
-        ns = time_func()
-        last = _last
+    if ms is None:
+        ms = time_func()
     else:
-        last = _last_as_of
-        ns = int(ns)  # Fail fast if not an int
+        ms = int(ms)  # Fail fast if not an int
 
-    if ns == 0:
-        # Special cose for all-zero uuid. Strictly speaking not a UUIDv7.
-        t1 = t2 = t3 = t4 = 0
-        rand = b"\0" * 6
-    else:
-        # Treat the first 8 bytes of the uuid as a long (t1) and two ints
-        # (t2 and t3) holding 36 bits of whole seconds and 24 bits of
-        # fractional seconds.
-        # This gives a nominal 60ns resolution, comparable to the
-        # timestamp precision in Linux (~200ns) and Windows (100ns ticks).
-        sixteen_secs = 16_000_000_000
-        t1, rest1 = divmod(ns, sixteen_secs)
-        t2, rest2 = divmod(rest1 << 16, sixteen_secs)
-        t3, _ = divmod(rest2 << 12, sixteen_secs)
-        t3 |= 7 << 12  # Put uuid version in top 4 bits, which are 0 in t3
+    rand_a = int.from_bytes(os.urandom(2))
+    rand_b = int.from_bytes(os.urandom(8))
+    uuid_bytes = uuidfromvalues(ms, rand_a, rand_b)
 
-        # The next two bytes are an int (t4) with two bits for
-        # the variant 2 and a 14 bit sequence counter which increments
-        # if the time is unchanged.
-        if t1 == last[0] and t2 == last[1] and t3 == last[2]:
-            # Stop the seq counter wrapping past 0x3FFF.
-            # This won't happen in practice, but if it does,
-            # uuids after the 16383rd with that same timestamp
-            # will not longer be correctly ordered but
-            # are still unique due to the 6 random bytes.
-            if last[3] < 0x3FFF:
-                last[3] += 1
-        else:
-            last[:] = (t1, t2, t3, 0)
-        t4 = (2 << 14) | last[3]  # Put variant 0b10 in top two bits
-
-        # Six random bytes for the lower part of the uuid
-        rand = os.urandom(6)
-
-    # Build output
-    if as_type == "str":
-        return f"{t1:>08x}-{t2:>04x}-{t3:>04x}-{t4:>04x}-{rand.hex()}"
-
-    r = int.from_bytes(rand, "big")
-    uuid_int = (t1 << 96) + (t2 << 80) + (t3 << 64) + (t4 << 48) + r
+    uuid_int = int.from_bytes(uuid_bytes)
     if as_type == "int":
-        return uuid_int
+        return int.from_bytes(uuid_bytes)
+    elif as_type == "bin":
+        return bin(int.from_bytes(uuid_bytes))
     elif as_type == "hex":
         return f"{uuid_int:>032x}"
     elif as_type == "bytes":
         return uuid_int.to_bytes(16, "big")
+    elif as_type == "str":
+        return format_byte_array_as_uuid(uuid_bytes)
     else:
         return uuid.UUID(int=uuid_int)
 
 
-def uuid7str(ns: Optional[int] = None) -> str:
+def uuidfromvalues(unix_ts_ms: int, rand_a: int, rand_b: int):
+    version = 0x07
+    var = 2
+    rand_a &= 0xfff
+    rand_b &= 0x3fffffffffffffff
+
+    final_bytes = unix_ts_ms.to_bytes(6)
+    final_bytes += ((version<<12)+rand_a).to_bytes(2)
+    final_bytes += ((var<<62)+rand_b).to_bytes(8)
+
+    return final_bytes
+
+def format_byte_array_as_uuid(arr: bytes):
+    return f"{arr[:4].hex()}-{arr[4:6].hex()}-{arr[6:8].hex()}-{arr[8:10].hex()}-{arr[10:].hex()}"
+
+def uuid7str(ms: Optional[int] = None) -> str:
     "uuid7() as a string without creating a UUID object first."
-    return uuid7(ns, as_type="str")  # type: ignore
+    return uuid7(ms, as_type="str")  # type: ignore
 
 
 def check_timing_precision(
@@ -233,7 +209,7 @@ rather than {ideal_precision_ns:0,.0f}ns ({ctr:,} samples of which \
     return "\n".join(lines)
 
 
-def timestamp_ns(
+def timestamp_ms(
     s: Union[str, uuid.UUID, int],
     suppress_error=True,
 ) -> Optional[int]:
@@ -245,8 +221,8 @@ def timestamp_ns(
     or return None, depending on suppress_error.
 
     Usage:
-    >>> uuid_to_datetime("1eb22fe4-3f0c-62b1-a88c-8dc55231702f")
-    datetime.datetime(2020, 11, 10, 2, 41, 42, 182162)
+    >>> uuid_to_datetime("017f22e2-79b0-7cc3-98c4-dc0c0c07398f")
+    datetime.datetime(2022, 2, 23, 6, 22, 22)
     """
     if isinstance(s, uuid.UUID):
         x = s.bytes
@@ -260,18 +236,7 @@ def timestamp_ns(
 
     uuid_version = x[6] >> 4
     if uuid_version == 7:
-        bits = struct.unpack(">IHHHHI", x)
-        uuid_version = (bits[2] >> 12) & 0xF
-        # uuid_variant = (bits[3] >> 62) & 0x3
-        whole_secs = (bits[0] << 4) + (bits[1] >> 12)
-        frac_binary = (
-            ((bits[1] & 0x0FFF) << 26)
-            + ((bits[2] & 0x0FFF) << 14)
-            + ((bits[3] & 0x3FFF))
-        )
-        frac_ns, _ = divmod(frac_binary * 1_000_000_000, 1 << 38)
-        ns_since_epoch = whole_secs * 1_000_000_000 + frac_ns
-        return ns_since_epoch
+        return int.from_bytes(x[:6])
     elif suppress_error:
         return None
     else:
@@ -285,11 +250,11 @@ def uuid_to_datetime(
     s: Union[str, uuid.UUID, int],
     suppress_error=True,
 ) -> Optional[datetime.datetime]:
-    ns_since_epoch = timestamp_ns(s, suppress_error=suppress_error)
-    if ns_since_epoch is None:
+    ms_since_epoch = timestamp_ms(s, suppress_error=suppress_error)
+    if ms_since_epoch is None:
         return None
     else:
         return datetime.datetime.fromtimestamp(
-            ns_since_epoch / 1_000_000_000,
+            ms_since_epoch / 1_000,
             tz=datetime.timezone.utc,
         )


### PR DESCRIPTION
I noticed that the UUIDs from this library weren't matching what I was getting from packages in npm. I then saw this issue which said it was definitely a problem:
https://github.com/stevesimmons/uuid7/issues/1

I've gone ahead and dropped nanosecond support to get this library matching the results of other ones. It looks like the variable accuracy timestamps have been dropped from the latest draft I can find of the UUIDv7 spec and it's just millisecond accuracy now: https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-04.html#name-uuid-version-7

Let me know if you think I've done anything wrong or you're not happy with a direction I've taken. Happy to fix up any issues.

