### PR TITLE
Improve typing using overloads

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include uuid_extensions/py.typed
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ lint/black: ## check style with black
 
 lint: lint/flake8 lint/black ## check style
 
+typecheck:
+	mypy uuid_extensions
+
 test: ## run tests quickly with the default Python
 	pytest
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,4 @@ pytest==6.2.4
 black==21.7b0
 
 typing_extensions==4.12.2
+mypy==1.13.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 pip==19.2.3
-bump2version==0.5.11
+bump2version==1.0.1
 wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
@@ -10,3 +10,5 @@ twine==1.14.0
 
 pytest==6.2.4
 black==21.7b0
+
+typing_extensions==4.12.2


### PR DESCRIPTION
At the moment, the typing is partial and requires `cast` due to the missing overloads.

I did not see that those MR exists before fixing it

* https://github.com/stevesimmons/uuid7/pull/3
* https://github.com/stevesimmons/uuid7/pull/4


The #3 exposes private argument in the overloads, which sounds a bad idea to me, it also introduce a breakding changes by enforcing kwargs. So I kept the MR open.
